### PR TITLE
Adds simple support for jqGrid Filtering

### DIFF
--- a/Pager/Handler/Http/JqGridHandler.php
+++ b/Pager/Handler/Http/JqGridHandler.php
@@ -27,10 +27,9 @@ class JqGridHandler extends AbstractHandler
             $pager->setOrderBy(new OrderBy(array($field => $order)));
         }
 
-        if( $this->has($request, 'filters')) {
+        if($this->has($request, 'filters')) {
             $filters = $this->get($request, 'filters');
-            if( isset( $filters['rules']) && isset($filters['groupOp']) )
-            {
+            if(isset($filters['rules']) && isset($filters['groupOp'])) {
                 $rules = $filters['rules'];
                 $groupOp = (($filters['groupOp'] == 'OR') ? Filter::LOGICAL_OR : Filter::LOGICAL_AND);
 


### PR DESCRIPTION
I've added simple support for filtering. It works. I've tested it using a custom search form and setting the filters manually via Js. Applying the filters and reloading the grid will show the filtered results.
